### PR TITLE
UX: adds component flag so that the theme is imported as a theme component

### DIFF
--- a/about.json
+++ b/about.json
@@ -2,6 +2,7 @@
   "name": "Plugin Outlets",
   "about_url": "https://www.discoursehosting.com/",
   "license_url": "URL",
+  "component": true,
   "assets": {
   },
   "color_schemes": {


### PR DESCRIPTION
Pretty minor, but adding 

`component: true` 

to the `about.json` file ensures that this theme is imported as a theme component and not as a theme. 

The flag is supported by all branches of Discourse, including the stable branch. 



