### PR TITLE
✨ FEATURE: Ability to toggle visibility of plugin outlet locations

### DIFF
--- a/javascripts/discourse/api-initializers/plugin-outlets-theme-component.js
+++ b/javascripts/discourse/api-initializers/plugin-outlets-theme-component.js
@@ -4,6 +4,24 @@ import { h } from 'virtual-dom';
 
 export default apiInitializer('0.11.1', (api) => {
   let icon = iconNode('plug');
+
+  api.onPageChange(() => {
+    const outlets = document.querySelectorAll('.outlet');
+    const visibility = localStorage.getItem('plugin-outlet-visibility');
+    console.log(visibility);
+    if (visibility === null) {
+      localStorage.setItem('plugin-outlet-visibility', 'outlets-visible');
+    } else if (visibility === 'outlets-invisible') {
+      outlets.forEach((outlet) => {
+        outlet.style.display = 'none';
+      });
+    } else if (visibility === 'outlets-visible') {
+      outlets.forEach((outlet) => {
+        outlet.style.display = 'block';
+      });
+    }
+  });
+
   api.decorateWidget('header-icons:before', () => {
     return h('li.header-dropdown-toggle', [
       h(
@@ -22,8 +40,10 @@ export default apiInitializer('0.11.1', (api) => {
     outlets.forEach((outlet) => {
       if (outlet.style.display === 'none') {
         outlet.style.display = 'block';
+        localStorage.setItem('plugin-outlet-visibility', 'outlets-visible');
       } else {
         outlet.style.display = 'none';
+        localStorage.setItem('plugin-outlet-visibility', 'outlets-invisible');
       }
     });
   });

--- a/javascripts/discourse/api-initializers/plugin-outlets-theme-component.js
+++ b/javascripts/discourse/api-initializers/plugin-outlets-theme-component.js
@@ -1,3 +1,30 @@
+import { iconNode } from 'discourse-common/lib/icon-library';
 import { apiInitializer } from 'discourse/lib/api';
+import { h } from 'virtual-dom';
+
 export default apiInitializer('0.11.1', (api) => {
+  let icon = iconNode('plug');
+  api.decorateWidget('header-icons:before', () => {
+    return h('li.header-dropdown-toggle', [
+      h(
+        'a.icon.btn-flat#toggle-plugin-outlets',
+        {
+          title: 'Toggle Outlets',
+        },
+        icon
+      ),
+    ]);
+  });
+
+  api.attachWidgetAction('header-icons', 'click', function (e) {
+    const outlets = document.querySelectorAll('.outlet');
+
+    outlets.forEach((outlet) => {
+      if (outlet.style.display === 'none') {
+        outlet.style.display = 'block';
+      } else {
+        outlet.style.display = 'none';
+      }
+    });
+  });
 });

--- a/javascripts/discourse/api-initializers/plugin-outlets-theme-component.js
+++ b/javascripts/discourse/api-initializers/plugin-outlets-theme-component.js
@@ -8,7 +8,7 @@ export default apiInitializer('0.11.1', (api) => {
   api.onPageChange(() => {
     const outlets = document.querySelectorAll('.outlet');
     const visibility = localStorage.getItem('plugin-outlet-visibility');
-    console.log(visibility);
+
     if (visibility === null) {
       localStorage.setItem('plugin-outlet-visibility', 'outlets-visible');
     } else if (visibility === 'outlets-invisible') {

--- a/javascripts/discourse/api-initializers/plugin-outlets-theme-component.js
+++ b/javascripts/discourse/api-initializers/plugin-outlets-theme-component.js
@@ -1,0 +1,3 @@
+import { apiInitializer } from 'discourse/lib/api';
+export default apiInitializer('0.11.1', (api) => {
+});


### PR DESCRIPTION
Adds the ability to toggle the visibility of where plugin outlets are present. This is useful so that you can keep this theme component installed during development without it hindering your view. When you want to see the outlets you can toggle it back on easily.


<img width="696" alt="Screen Shot 2021-11-12 at 11 43 12 AM" src="https://user-images.githubusercontent.com/30090424/141526060-96b2a459-d258-4d75-acb0-c7a22a0f38ee.png">
<img width="696" alt="Screen Shot 2021-11-12 at 11 43 15 AM" src="https://user-images.githubusercontent.com/30090424/141526064-a2409d9f-9ad6-4543-9836-d0a68f2f0fd8.png">


